### PR TITLE
Switch to static images, to allow GH page hosting

### DIFF
--- a/components/common/tweet-card/tweet-card.tsx
+++ b/components/common/tweet-card/tweet-card.tsx
@@ -22,7 +22,7 @@ export const TweetCard: React.FC<TweetCardProps> = ({ name, handle, text, date, 
   return (
     <div className={styles.card}>
       <div className={styles.header}>
-        <img src={avatar} className={styles.avatar} alt={name} />
+        <img src={avatar} className={styles.avatar} alt={name} loading="lazy" />
         <strong className={styles.name}>{name}</strong>
         <span className={styles.handle}>
           <a href={url} className="link" onClick={onLinkClick}>

--- a/components/pages/collectives/collective-card/collective-card.tsx
+++ b/components/pages/collectives/collective-card/collective-card.tsx
@@ -30,7 +30,7 @@ export const CollectiveCard: React.FC<CollectiveCardProps> = (props) => {
   return (
     <div className={cn(styles.card, { [`${styles.cardPromo}`]: promo })}>
       <div className={styles.image}>
-        {promo ? <PromoImage /> : <img src={imageSrc} alt={title} />}
+        {promo ? <PromoImage /> : <img src={imageSrc} alt={title} loading="lazy" />}
       </div>
       <div className={styles.body}>
         <strong className={styles.title}>{title}</strong>

--- a/components/pages/developer/icon-box/icon-box.tsx
+++ b/components/pages/developer/icon-box/icon-box.tsx
@@ -31,10 +31,11 @@ export const IconBox: React.FC<IconBoxProps> = (props) => {
       {iconComponent && <Icon component={iconComponent} />}
       {imageUrl && (
         <span className={styles.image}>
-          <Image
+          <img
             src={imageUrl}
             alt={headline}
-            layout="fixed"
+            loading="lazy"
+            // layout="fixed"
             width={imageWidth}
             height={imageHeight}
           />

--- a/components/pages/developer/icon-card/icon-card.tsx
+++ b/components/pages/developer/icon-card/icon-card.tsx
@@ -10,7 +10,7 @@ interface IconCardProps {
 export const IconCard: React.FC<IconCardProps> = ({ headline, children, iconSrc }) => {
   return (
     <div className={styles.card}>
-      <img src={iconSrc} alt={headline} className={styles.icon} />
+      <img src={iconSrc} alt={headline} className={styles.icon} loading="lazy" />
       <strong className={styles.headline}>{headline}</strong>
       <p className={styles.text}>{children}</p>
     </div>

--- a/components/pages/home/03_collective/collective.tsx
+++ b/components/pages/home/03_collective/collective.tsx
@@ -79,13 +79,14 @@ const MobileBackground: React.FC<{ section: 'top' | 'bottom' }> = ({ section }) 
   return (
     <div className={bg.className}>
       <div className={styles.backgroundMobileInner} style={{ left: val }}>
-        <Image
+        <img
           src={bg.image.src}
-          alt=""
-          layout="fixed"
+          alt="Edgeware Collectives"
+          loading="lazy"
+          // layout="fixed"
           width={bg.image.width}
           height={bg.image.height}
-          quality={100}
+          // quality={100}
         />
       </div>
     </div>
@@ -104,14 +105,14 @@ const DesktopBackground: React.FC = () => {
   return (
     <div className={styles.background}>
       <div className={styles.backgroundInner} style={{ left: val }}>
-        <Image
+        <img
           src="/images/home/collectives-desktop.png"
-          alt=""
-          layout="fixed"
+          alt="Edgeware Collectives"
+          // layout="fixed"
           width="1732"
           loading="eager"
           height="1479"
-          quality={100}
+          // quality={100}
         />
       </div>
     </div>

--- a/components/pages/home/04_structure/structure.module.scss
+++ b/components/pages/home/04_structure/structure.module.scss
@@ -28,7 +28,7 @@
     margin-top: -60px;
   }
 
-  svg {
+  svg, img {
     max-width: 100%;
     height: auto;
   }

--- a/components/pages/home/04_structure/structure.tsx
+++ b/components/pages/home/04_structure/structure.tsx
@@ -91,20 +91,22 @@ const StructureChart: React.FC<{ inView: boolean }> = ({ inView }) => {
       className={styles.treasuryModel}
     >
       <div className={styles.treasuryModelSimple}>
-        <Image
+        <img
           src="/images/home/treasury-simple.png"
           width="1134"
           height="1094"
-          quality="100"
+          loading="lazy"
+          // quality="100"
           alt="Edgeware organization simple model"
         />
       </div>
       <div className={styles.treasuryModelFull}>
-        <Image
+        <img
           src="/images/home/treasury-full.png"
           width="1134"
           height="1094"
-          quality="100"
+          loading="lazy"
+          // quality="100"
           alt="Edgeware organization full model"
         />
       </div>

--- a/components/pages/home/05_projects/projects-slider/project-slide.tsx
+++ b/components/pages/home/05_projects/projects-slider/project-slide.tsx
@@ -30,7 +30,7 @@ export const ProjectSlide: React.FC<ProjectSlideProps> = (props) => {
         <Button>Visit Project</Button>
       </div>
       <div className={styles.slideImage}>
-        <img src={imageUrl} alt={headline} />
+        <img src={imageUrl} alt={headline} loading="lazy" />
       </div>
     </div>
   );

--- a/components/pages/home/06_token/token-distribution/token-distribution.module.scss
+++ b/components/pages/home/06_token/token-distribution/token-distribution.module.scss
@@ -15,6 +15,10 @@
   @include media-breakpoint-up(lg) {
     margin: var(--spacing-xl) 0;
   }
+
+  img {
+    width: 100%;
+  }
 }
 
 .tokenDistributionBig {

--- a/components/pages/home/06_token/token-distribution/token-distribution.tsx
+++ b/components/pages/home/06_token/token-distribution/token-distribution.tsx
@@ -13,20 +13,22 @@ export const TokenDistribution: React.FC = ({ children }) => {
         <div className="col-12 col-md-8">
           <div className={styles.tokenDistribution}>
             <span className={styles.tokenDistributionBig}>
-              <Image
+              <img
                 src="/images/home/token/edg-distribution-chart-desktop.png"
                 width="1492"
                 height=" 614"
-                quality="100"
+                loading="lazy"
+                // quality="100"
               />
             </span>
             <span className={styles.tokenDistributionSmall}>
-              <Image
+              <img
                 src="/images/home/token/edg-distribution-chart-mobile.png"
                 width="320"
                 height="539"
-                quality="100"
-                layout="fixed"
+                loading="lazy"
+                // quality="100"
+                // layout="fixed"
               />
             </span>
           </div>

--- a/components/pages/home/06_token/token-wallet/token-wallet.tsx
+++ b/components/pages/home/06_token/token-wallet/token-wallet.tsx
@@ -14,21 +14,23 @@ export const TokenWallet: React.FC<TokenWalletProps> = ({ headline }) => {
 
       <div className={styles.walletLinks}>
         <a href="https://polkadot.js.org/apps/" className={styles.walletLink}>
-          <Image
+          <img
             src="/images/home/token/logo-polkadot.png"
-            layout="fixed"
+            // layout="fixed"
             width="40"
             height="55"
             alt="Polkadot{.js}"
+            loading="lazy"
           />
         </a>
         <a href="https://mathwallet.org/en-us/" className={styles.walletLink}>
-          <Image
+          <img
             src="/images/home/token/logo-mathwallet.png"
-            layout="fixed"
+            // layout="fixed"
             width="96"
             height="53"
             alt="Math Wallet"
+            loading="lazy"
           />
         </a>
       </div>

--- a/components/pages/home/06_token/token-widget/token-widget.tsx
+++ b/components/pages/home/06_token/token-widget/token-widget.tsx
@@ -49,7 +49,7 @@ export const TokenWidget: React.FC = () => {
       </div>
       <div className={styles.tokenInfo}>
         <span className={styles.coingeckoLogo}>
-          <img src="/images/home/token/coingecko-logo.png" alt="CoinGecko" />
+          <img src="/images/home/token/coingecko-logo.png" alt="CoinGecko" loading="lazy"/>
         </span>
         Live prices from CoinGecko
       </div>

--- a/components/pages/press/brand-assets/brand-assets.tsx
+++ b/components/pages/press/brand-assets/brand-assets.tsx
@@ -22,7 +22,7 @@ export const BrandAsset: React.FC<BrandAssetProps> = ({ type, name, color }) => 
           styles[`assetImage-${type}`]
         )}
       >
-        <img src={logoPath(type, color, 'svg')} alt={`Logo asset ${name}`} />
+        <img src={logoPath(type, color, 'svg')} alt={`Logo asset ${name}`} loading="lazy" />
       </div>
       <div className={styles.assetMeta}>
         <span className={styles.assetName}>{name}</span>

--- a/pages/developers.tsx
+++ b/pages/developers.tsx
@@ -57,9 +57,10 @@ export default function Developer() {
           <div className="row">
             <div className="col-lg">
               <div className="px-md-5 mx-md-1">
-                <Image
+                <img
                   src="/images/developer/code-s-slash-large.png"
-                  layout="responsive"
+                  // layout="responsive"
+                  loading="lazy"
                   width="474"
                   height="472"
                 />


### PR DESCRIPTION
Since we're going to host the page on static Github Pages, unfortunately Next.js does not support [built in Image Optimizations](https://nextjs.org/docs/basic-features/image-optimization) in case of full static export (which we need for GH pages).

So for now I've replaced usage of Next `Image` component, with native `img` tag with `loading="lazy"` - to keep at least some of the performance benefits of this kind of optimizations.

I'll investigate this in future, how we can optimize images even further, if it would lead to some performance issues (we need to test this a bit more). For now it should be good to go (we did some preliminary testing with @jsteneros ).