### PR TITLE
Migrate standalone Edgeware keygen tools into internal website page

### DIFF
--- a/components/common/section/section.module.scss
+++ b/components/common/section/section.module.scss
@@ -8,6 +8,10 @@
   padding: var(--spacing-xs) 0;
 }
 
+.sectionGap-narrow {
+  padding: var(--spacing-s) 0;
+}
+
 .sectionGap-standard {
   padding: var(--spacing-m) 0;
   margin: 0 0 var(--spacing-m) 0;

--- a/components/common/section/section.tsx
+++ b/components/common/section/section.tsx
@@ -7,7 +7,7 @@ interface SectionProps {
   id: string;
   background?: 'none' | 'waves' | 'waves-middle' | 'waves-top';
   width: 'narrow' | 'normal' | 'wide' | 'fluid';
-  gap?: 'none' | 'standard';
+  gap?: 'none' | 'narrow' | 'standard';
 }
 
 export const Section: React.FC<SectionProps> = ({

--- a/components/pages/keygen/address-converter/address-converter.module.scss
+++ b/components/pages/keygen/address-converter/address-converter.module.scss
@@ -1,0 +1,86 @@
+@import '../../../../styles/custom.scss';
+
+.form {
+  margin: 0;
+  padding: 0;
+
+  @include media-breakpoint-up(lg) {
+    margin: var(--spacing-m) 0;
+  }
+}
+
+.fieldset {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.formRow {
+  margin: var(--spacing-s) 0 0 0;
+
+  display: flex;
+  flex-direction: column;
+
+  @include media-breakpoint-up(lg) {
+    flex-direction: row;
+  }
+}
+
+.input {
+  width: 100%;
+  border-radius: var(--br-m);
+  border: solid 1px var(--grey-600);
+  padding: 12px var(--spacing-s) 12px var(--spacing-s);
+  margin: 0 0 var(--spacing-xs) 0;
+  font-size: 1rem;
+  font-family: var(--ff-plex);
+
+  &:focus {
+    outline: none;
+    border: solid 1px var(--grey-900);
+  }
+
+  @include media-breakpoint-up(lg) {
+    padding: 12px var(--spacing-s);
+    margin: 0;
+    width: 620px;
+    height: 61px;
+  }
+}
+
+.button {
+  font-size: 1.25rem;
+  color: var(--bw-white);
+  background-color: var(--grey-800);
+  border-radius: var(--br-m);
+  border: solid 1px var(--grey-700);
+  padding: 10px var(--spacing-m);
+  display: block;
+  width: 100%;
+
+  @include media-breakpoint-up(lg) {
+    width: auto;
+    display: inline-block;
+    padding: 12px var(--spacing-m);
+    border-radius: 0 var(--br-m) var(--br-m) 0;
+    margin-left: -8px;
+  }
+
+  @include media-breakpoint-up(xl) {
+    padding: 12px var(--spacing-l);
+  }
+}
+
+.infoBox {
+  padding: var(--spacing-m);
+  margin: var(--spacing-m) 0;
+  font-size: var(--fs-text-xl);
+
+  border: 1px solid var(--grey-700);
+  border-radius: var(--br-m);
+
+  pre {
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/components/pages/keygen/address-converter/address-converter.tsx
+++ b/components/pages/keygen/address-converter/address-converter.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react'
+
+import { Button } from '../../../common/button/button'
+
+import { evmConvert, ss58Convert, publicKeyConvert} from '../../../../lib/keygen'
+import { P } from '../../../common/typography/typography'
+
+import styles from './address-converter.module.scss'
+
+// interface KeyPairGeneratorState {
+//   generated: boolean
+//   keypairData?: KeyPairData
+// }
+
+type ConverterType = 'evm-address' | 'ss58-address' | 'public-key'
+
+interface AddressConverterProps {
+  type: ConverterType
+}
+
+const FORM_LABELS = {
+  'evm-address': 'EVM Address (e.g. 0x1234...)',
+  'ss58-address': 'Testnet EDG Address (e.g. 5G7Agn...)',
+  'public-key': 'Public key (e.g. 0x1234...)'
+}
+
+const FORM_CONVERTERS = {
+  'evm-address': evmConvert,
+  'ss58-address': ss58Convert,
+  'public-key': publicKeyConvert
+}
+
+function convertInputByType(input: string, type: ConverterType) {
+  return FORM_CONVERTERS[type](input)
+}
+
+
+export const AddressConverter: React.FC<AddressConverterProps> = ({ type }) => {
+  const [results, setResults] = React.useState({
+    inputValue: '',
+    data: undefined
+  })
+
+  const inputEl = React.useRef(null);
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const inputValue = inputEl.current.value
+    const data = convertInputByType(inputValue, type)
+    setResults({
+      inputValue,
+      data
+    })
+  }
+
+  const handleReset = () => {
+    setResults({
+      inputValue: '',
+      data: undefined
+    })
+  }
+
+  if (results.data) {
+    let resultText = ''
+    if (results.data === 'error') {
+      resultText = 'Invalid input data!'
+    } else if (type === 'evm-address') {
+      resultText = `Address: ${results.inputValue}
+Converted address: ${results.data}`
+    } else if (type === 'public-key') {
+      resultText = `Public Key: ${results.inputValue}
+Testnet address (SS58): ${results.data.testnetAddress}
+Mainnet address (SS58): ${results.data.mainnetAddress}`
+    } else if (type === 'ss58-address') {
+      resultText = `Address: ${results.inputValue}
+Public Key: ${results.data}`
+    }
+
+    return (
+      <>
+        <div className={styles.infoBox}>
+          <pre>{resultText}</pre>
+        </div>
+        <Button onClick={handleReset} style="secondary">Start over</Button>
+      </>
+    )
+  }
+
+  return (
+    <form className={styles.form} action="#" onSubmit={handleSubmit}>
+      <fieldset className={styles.fieldset}>
+        <div className={styles.formRow}>
+          <label htmlFor={`ac-input-${type}`} aria-label={FORM_LABELS[type]}>
+            <input
+              id={`ac-input-${type}`}
+              className={styles.input}
+              type="text"
+              name="input"
+              placeholder={FORM_LABELS[type]}
+              ref={inputEl}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+            />
+          </label>
+          <button type="submit" className={styles.button}>
+            Convert
+          </button>
+        </div>
+      </fieldset>
+    </form>
+  )
+}

--- a/components/pages/keygen/keypair-generator/keypair-generator.module.scss
+++ b/components/pages/keygen/keypair-generator/keypair-generator.module.scss
@@ -1,0 +1,13 @@
+.infoBox {
+  padding: var(--spacing-m);
+  margin: var(--spacing-m) 0;
+  font-size: var(--fs-text-xl);
+
+  border: 1px solid var(--grey-700);
+  border-radius: var(--br-m);
+
+  pre {
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/components/pages/keygen/keypair-generator/keypair-generator.tsx
+++ b/components/pages/keygen/keypair-generator/keypair-generator.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+
+import { Button } from '../../../common/button/button'
+
+import { generateKeyPair, KeyPairData } from '../../../../lib/keygen'
+import { P } from '../../../common/typography/typography'
+
+import styles from './keypair-generator.module.scss'
+
+interface KeyPairGeneratorState {
+  generated: boolean
+  keypairData?: KeyPairData
+}
+
+function getFormattedData(keypairData: KeyPairData): string {
+  const { phrase, publicKey, testnetAddress, mainnetAddress } = keypairData
+
+  return `Mnemonic phrase: ${phrase}
+Public key (hex): ${publicKey}
+Testnet address (SS58): ${testnetAddress}
+Mainnet address (SS58): ${mainnetAddress}
+`
+}
+
+export const KeyPairGenerator: React.FC = () => {
+  const [results, setResults] = React.useState<KeyPairGeneratorState>({
+    generated: false
+  })
+
+  const handleClick = () => {
+    const keypairData = generateKeyPair()
+
+    setResults({
+      generated: true,
+      keypairData
+    })
+  }
+
+  const handleReset = () => {
+    setResults({
+      generated: false,
+      keypairData: undefined
+    })
+  }
+
+
+  if (results.generated) {
+    return (
+      <>
+        <div className={styles.infoBox}>
+          <pre>{getFormattedData(results.keypairData)}</pre>
+        </div>
+        <P><strong>
+          You've generated a public key and mnemonic. Save the mnemonic to a secure offline location!<br/>
+          If you don't remember your mnemonic, you won't be able to claim your EDG.
+          </strong></P>
+        <Button onClick={handleReset} style="secondary">Start over</Button>
+      </>
+    )
+  }
+
+  return (
+    <div>
+      <Button onClick={handleClick}>Generate key pair</Button>
+    </div>
+  )
+}

--- a/lib/keygen.ts
+++ b/lib/keygen.ts
@@ -1,0 +1,75 @@
+import { mnemonicGenerate } from '@polkadot/util-crypto';
+import { u8aToHex, hexToU8a, stringToU8a, u8aConcat } from '@polkadot/util';
+import { blake2AsU8a } from '@polkadot/util-crypto/blake2';
+import Keyring from '@polkadot/keyring';
+import { createPair } from '@polkadot/keyring/pair';
+
+const KEYRING_TYPE = 'sr25519'
+
+export interface KeyPairData {
+  phrase: string;
+  publicKey: string;
+  testnetAddress: string;
+  mainnetAddress: string
+}
+
+export function generateKeyPair(): KeyPairData {
+  const phrase = mnemonicGenerate();
+  const testnetKeyring = new Keyring({ type: KEYRING_TYPE });
+  const testnetKeyringPair = testnetKeyring.addFromMnemonic(phrase);
+  const mainnetKeyring = new Keyring({ type: KEYRING_TYPE, ss58Format: 7 });
+  const mainnetKeyringPair = mainnetKeyring.addFromMnemonic(phrase);
+
+  return {
+    phrase,
+    publicKey: u8aToHex(testnetKeyringPair.publicKey),
+    testnetAddress: testnetKeyringPair.address,
+    mainnetAddress: mainnetKeyringPair.address
+  }
+}
+
+export function evmConvert(evmAddress = '') {
+  try {
+    const addr = hexToU8a(evmAddress);
+    const data = stringToU8a('evm:');
+    const res = blake2AsU8a(u8aConcat(data, addr));
+
+    const mainnetKeyring = new Keyring({ type: 'sr25519', ss58Format: 7 });
+    const mainnetPair = createPair({ toSS58: mainnetKeyring.encodeAddress, type: 'sr25519' }, { publicKey: res });
+
+    const convertedMainnetAddress = mainnetPair.address;
+    return convertedMainnetAddress
+  } catch (e) {
+    return 'error'
+  }
+}
+
+export function ss58Convert(address = '') {
+  const keyring = new Keyring();
+  try {
+    keyring.addFromAddress(address);
+    const publicKey = u8aToHex(keyring.getPublicKeys()[0]);
+    return publicKey
+  } catch (e) {
+    return 'error'
+  }
+}
+
+export function publicKeyConvert(publicKey = '') {
+  try {
+    const testnetKeyring = new Keyring({ type: 'sr25519' });
+    const testnetPair = createPair({ toSS58: testnetKeyring.encodeAddress, type: 'sr25519' }, { publicKey: hexToU8a(publicKey) });
+    const testnetAddress = testnetPair.address;
+
+    const mainnetKeyring = new Keyring({ type: 'sr25519', ss58Format: 7 });
+    const mainnetPair = createPair({ toSS58: mainnetKeyring.encodeAddress, type: 'sr25519' }, { publicKey: hexToU8a(publicKey) });
+    const mainnetAddress = mainnetPair.address;
+
+    return {
+      testnetAddress,
+      mainnetAddress
+    }
+  } catch (e) {
+    return 'error';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test": "jest"
   },
   "dependencies": {
+    "@polkadot/keyring": "^6.3.1",
+    "@polkadot/util": "^6.3.1",
+    "@polkadot/util-crypto": "^6.3.1",
     "@popperjs/core": "^2.9.2",
     "bootstrap": "^5.0.0-beta3",
     "classnames": "^2.3.1",

--- a/pages/keygen.tsx
+++ b/pages/keygen.tsx
@@ -1,0 +1,67 @@
+
+import * as React from 'react';
+
+import { H1, H2, P } from '../components/common/typography/typography';
+import { Section } from '../components/common/section/section';
+import { KeyPairGenerator } from '../components/pages/keygen/keypair-generator/keypair-generator';
+import { AddressConverter } from '../components/pages/keygen/address-converter/address-converter';
+
+export default function Keygen() {
+  return (
+    <>
+      <Section id="intro" width="normal" gap="narrow">
+        <div>
+          <H1 size="1">Edgeware Key Generator</H1>
+          <P>
+            This page generates public/private keypairs, which you can use to receive EDG from the Edgeware lockdrop.
+            <br/>
+            Note: The preferred way to generate a private key is using the command line, on an air-gapped computer.
+          </P>
+        </div>
+      </Section>
+
+      <Section id="keypair" width="normal" gap="standard">
+        <H2>Generate keypair</H2>
+        <P>
+          Please keep in mind that this method to generate a public/private key pair is insecure!<br/>
+          The preferred way to generate a private key is using the command line or polkadot-js, on an air-gapped computer.
+        </P>
+
+        <KeyPairGenerator />
+      </Section>
+
+      <Section id="convert-pk" width="normal" gap="standard">
+        <H2>Convert public key to address</H2>
+        <P>If you have a public key (0x1234...), you can use this tool to convert it into a mainnet/testnet address. </P>
+
+        <AddressConverter type="public-key" />
+      </Section>
+
+      <Section id="convert-ss58" width="normal" gap="standard">
+        <H2>Convert address to public key</H2>
+        <P> If you have a testnet EDG address (5G7Agn...), you can use this tool to convert it into a public key (0x1234...)</P>
+
+        <AddressConverter type="ss58-address" />
+      </Section>
+
+      <Section id="convert-evm" width="normal" gap="standard">
+        <H2>Convert Metamask/EVM address to mainnet address</H2>
+        <P>If you have an Metamask EVM address (e.g. 0x1234...), you can use this tool to convert it into a mainnet address (e.g. i76Ux...) to use with polkadot-js.</P>
+
+        <AddressConverter type="evm-address" />
+      </Section>
+
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      meta: {
+        title: 'Edgeware Key Generator',
+        description: '',
+      },
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,6 +1035,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.17", "@babel/runtime@^7.13.9":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
@@ -1433,6 +1440,113 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
+"@polkadot/keyring@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.3.1.tgz#434847cc4fb134116691c07e05750e8388cbb2b7"
+  integrity sha512-uVWhdd4TVtLc4R2OtiKHJE5jgJZnuEognbgjl5RT2uKrCJYTsYnq0IeRTvMmtdPJAJvGeD3JTsX2ekgt3tJpuw==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/util" "6.3.1"
+    "@polkadot/util-crypto" "6.3.1"
+
+"@polkadot/networks@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.3.1.tgz#c5063681ea73f8b579f418d57d0eba2d4bb72292"
+  integrity sha512-oANup0CLGt75CPbE3gz2HUWUlqQKucImdb1TtStLXMUH+Aj8ZOnQFA2lwixzaRdx+ymPfmEL7GkF36i96OqQVw==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+
+"@polkadot/util-crypto@6.3.1", "@polkadot/util-crypto@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-6.3.1.tgz#5328da77bdee5064bc41f9dec0a76cc634690b88"
+  integrity sha512-fwH4t6EN2XACwJB2Z5xUyNo4mQ1RXJj0MgVaaLua8PbG0qq9tt4eaEbdVzrm7A6igIfsTntDoZISTfVjBcRtkQ==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/networks" "6.3.1"
+    "@polkadot/util" "6.3.1"
+    "@polkadot/wasm-crypto" "^4.0.2"
+    "@polkadot/x-randomvalues" "6.3.1"
+    base-x "^3.0.8"
+    base64-js "^1.5.1"
+    blakejs "^1.1.0"
+    bn.js "^4.11.9"
+    create-hash "^1.2.0"
+    elliptic "^6.5.4"
+    hash.js "^1.1.7"
+    js-sha3 "^0.8.0"
+    scryptsy "^2.1.0"
+    tweetnacl "^1.0.3"
+    xxhashjs "^0.2.2"
+
+"@polkadot/util@6.3.1", "@polkadot/util@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-6.3.1.tgz#410ee362ddb37f9c67af8f5897d977a7fd950ebf"
+  integrity sha512-M9pGaXSB67DZPckdNQU29wq5W7BUOh6qeu5LonzxpUek+riJfbiF9JOgZQ2Q/aEFYbd1hqLbOMsLRZLhSmlbYw==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/x-textdecoder" "6.3.1"
+    "@polkadot/x-textencoder" "6.3.1"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.11.9"
+    camelcase "^5.3.1"
+    ip-regex "^4.3.0"
+
+"@polkadot/wasm-crypto-asmjs@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.0.2.tgz#f42c353a64e1243841daf90e4bd54eff01a4e3cf"
+  integrity sha512-hlebqtGvfjg2ZNm4scwBGVHwOwfUhy2yw5RBHmPwkccUif3sIy4SAzstpcVBIVMdAEvo746bPWEInA8zJRcgJA==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+
+"@polkadot/wasm-crypto-wasm@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.0.2.tgz#89f9e0a1e4d076784d4a42bea37fc8b06bdd8bb6"
+  integrity sha512-de/AfNPZ0uDKFWzOZ1rJCtaUbakGN29ks6IRYu6HZTRg7+RtqvE1rIkxabBvYgQVHIesmNwvEA9DlIkS6hYRFQ==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+
+"@polkadot/wasm-crypto@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.0.2.tgz#9649057adee8383cc86433d107ba526b718c5a3b"
+  integrity sha512-2h9FuQFkBc+B3TwSapt6LtyPvgtd0Hq9QsHW8g8FrmKBFRiiFKYRpfJKHCk0aCZzuRf9h95bQl/X6IXAIWF2ng==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+    "@polkadot/wasm-crypto-asmjs" "^4.0.2"
+    "@polkadot/wasm-crypto-wasm" "^4.0.2"
+
+"@polkadot/x-global@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-6.3.1.tgz#cdb4883fa20e23411bdd5f50a5d5c92814a3106f"
+  integrity sha512-eFooGQdxJpiOsm3AKTSMInaecBKaQ/tqOUJNm/CpdJalCqTDMp/qzgj64Uflk9eUqGgk7jB7Q5FaQdyWsC0Mtg==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@types/node-fetch" "^2.5.10"
+    node-fetch "^2.6.1"
+
+"@polkadot/x-randomvalues@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.3.1.tgz#e2b91223277d7d7978c39e9d280fbc6526217d46"
+  integrity sha512-SZ5MUYm1fd1fgGFexMWbbG8zZgCS7b9QNKaIcnv1Dwlfp2meDoDlgoedn+1pCJ6VEa1adswqLHX4WbYA4D9ynA==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/x-global" "6.3.1"
+
+"@polkadot/x-textdecoder@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-6.3.1.tgz#ab0eec87d5df2d119480fa7a3657d8d72f583af8"
+  integrity sha512-lLb11yaAmyx2STw7ZmdgPtV7LI26U/5h1K527cM7QnxgTQgYggtAt4f9aLHiWsmOCvnT0U0PWsWSUbAJrLHLBA==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/x-global" "6.3.1"
+
+"@polkadot/x-textencoder@6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.3.1.tgz#2277770650f5637698d7d8cd7ac0cfd5ca0dace2"
+  integrity sha512-7V5OuT43JPTm7rrwdBEMzXAF5nLg+t6q24ntZHNcFUH1pdkP/+2f3vGM3e9BK5k4wkQLoepod5gyY6Qbw9bsYQ==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
+    "@polkadot/x-global" "6.3.1"
+
 "@popperjs/core@2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
@@ -1641,6 +1755,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^4.11.6":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bootstrap@^5.0.12":
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/@types/bootstrap/-/bootstrap-5.0.12.tgz#d044b6404bf3c89fc90df2822a86dfcd349db522"
@@ -1711,6 +1832,14 @@
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/node-fetch@^2.5.10":
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
+  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*":
   version "14.14.37"
@@ -2286,7 +2415,14 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base-x@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+base64-js@^1.0.2, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2326,10 +2462,20 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+blakejs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
+  integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
+
+bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.3"
@@ -2390,7 +2536,7 @@ broadcast-channel@^3.4.1:
     rimraf "3.0.2"
     unload "2.2.0"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -2782,7 +2928,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3053,6 +3199,11 @@ csstype@^3.0.2, csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
   integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 damerau-levenshtein@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
@@ -3295,6 +3446,19 @@ elliptic@^6.5.3:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+elliptic@^6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 email-addresses@^3.0.1:
   version "3.1.0"
@@ -3925,6 +4089,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -4250,7 +4423,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -4268,7 +4441,7 @@ hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -4450,6 +4623,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ip-regex@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -5188,7 +5366,7 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
-js-sha3@0.8.0:
+js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -5859,7 +6037,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -7026,6 +7204,11 @@ screenfull@^5.1.0:
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.1.0.tgz#85c13c70f4ead4c1b8a935c70010dfdcd2c0e5c8"
   integrity sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA==
 
+scryptsy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
+  integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -7900,6 +8083,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -8333,6 +8521,13 @@ xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
This PR will integrate standalone Edgeware tools, we host currently at https://edgewa.re/keygen/ (and https://github.com/Edgeware-Network/edgeware-keygen) into simple, custom page.

- Migrated the logic generation logic and the address converters into lib functions
- Added React components to render forms with our styleguide
- Removed old static folder with the old page

The results:

![Screen Shot 2021-05-08 at 18 10 15-fullpage](https://user-images.githubusercontent.com/16012/117546092-004b1380-b029-11eb-9e56-b057d377ab80.png)

