### PR TITLE
Add partners page link to navigatigation + bunch of fixes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,17 @@
+name: Check build
+on: [pull_request]
+jobs:
+  test_and_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Install dependencies 🔧
+        run: yarn
+
+      - name: Test 🎢
+        run: yarn test
+
+      - name: Build and generate static export 🏗
+        run: yarn export

--- a/components/common/section/section.tsx
+++ b/components/common/section/section.tsx
@@ -23,10 +23,7 @@ export const Section: React.FC<SectionProps> = ({
     styles[`background--${background}`]
   );
 
-  const containerClass = cn(
-    styles.container,
-    styles[`container--${width}`]
-  );
+  const containerClass = cn(styles.container, styles[`container--${width}`]);
 
   return (
     <section id={id} className={sectionClasses}>

--- a/components/common/static-hero/static-hero.tsx
+++ b/components/common/static-hero/static-hero.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-
 import cn from 'classnames';
 
 import { H1, P } from '../typography/typography';
@@ -8,13 +7,12 @@ import { H1, P } from '../typography/typography';
 import styles from './static-hero.module.scss';
 
 interface StaticHeroProps {
-  headline: React.ReactNode
-  leadText?: string
-  heroStyle: 'jobs' | 'partners'
+  headline: React.ReactNode;
+  leadText?: string;
+  heroStyle: 'jobs' | 'partners';
 }
 
 export const StaticHero: React.FC<StaticHeroProps> = ({ headline, leadText, heroStyle }) => {
-
   return (
     <div className={cn(styles.hero, styles[`hero--${heroStyle}`])}>
       <div className={styles.wrapper}>
@@ -23,11 +21,7 @@ export const StaticHero: React.FC<StaticHeroProps> = ({ headline, leadText, hero
             <H1 size="1" className={styles.headline}>
               {headline}
             </H1>
-            {leadText && (
-              <P className={styles.leadText}>
-                {leadText}
-              </P>)
-            }
+            {leadText && <P className={styles.leadText}>{leadText}</P>}
           </div>
         </div>
       </div>

--- a/components/layout/header/header-nav.tsx
+++ b/components/layout/header/header-nav.tsx
@@ -55,29 +55,23 @@ export const NavItems: React.FC<NavItemsProps> = ({ style, onClick, onToggleModa
     onToggleModal();
   };
 
+  const ITEMS = {
+    Home: '/',
+    Collectives: '/collectives',
+    Partners: '/partners',
+    Developers: '/developers',
+    Mission: '/mission',
+    News: 'https://blog.edgewa.re/',
+    Docs: 'https://main.edgeware.wiki/',
+  };
+
   return (
     <nav className={cn(styles.nav, style === 'mobile' && styles.navMobile)}>
-      <NavItem href="/" onClick={onClick}>
-        Home
-      </NavItem>
-      <NavItem href="/collectives" onClick={onClick}>
-        Collectives
-      </NavItem>
-      <NavItem href="https://commonwealth.im/edgeware/proposals" onClick={onClick}>
-        Proposals
-      </NavItem>
-      <NavItem href="/developers" onClick={onClick}>
-        Developers
-      </NavItem>
-      <NavItem href="/mission" onClick={onClick}>
-        Mission
-      </NavItem>
-      <NavItem href="https://blog.edgewa.re/" onClick={onClick}>
-        News
-      </NavItem>
-      <NavItem href="https://main.edgeware.wiki/" onClick={onClick}>
-        Docs
-      </NavItem>
+      {Object.entries(ITEMS).map((entry) => (
+        <NavItem key={entry[0]} href={entry[1]} onClick={onClick}>
+          {entry[0]}
+        </NavItem>
+      ))}
       <NavButtonItem onClick={handleGetStartedClick}>Get Started</NavButtonItem>
     </nav>
   );

--- a/components/pages/partners/partner-card/partner-card.tsx
+++ b/components/pages/partners/partner-card/partner-card.tsx
@@ -15,29 +15,24 @@ export interface PartnerCardProps {
 }
 
 const getImagePathFromName = (name: string) => {
-  const filename = slugify(name, { lower: true })
-  return `/images/partners/${filename}.png`
-}
+  const filename = slugify(name, { lower: true });
+  return `/images/partners/${filename}.png`;
+};
 
 export const PartnerCard: React.FC<PartnerCardProps> = ({
   name,
   description,
   link,
-  funded = false
+  funded = false,
 }) => {
-
-  const iconHref = getImagePathFromName(name)
+  const iconHref = getImagePathFromName(name);
 
   return (
     <div className={styles.partnerCard} data-name={name}>
       <div className={styles.content}>
         <span className={styles.logoImageWrapper}>
           <span className={styles.logoImage}>
-            <img
-              src={iconHref}
-              alt={name}
-              loading="lazy"
-            />
+            <img src={iconHref} alt={name} loading="lazy" />
           </span>
         </span>
         <h4 className={styles.name}>{name}</h4>

--- a/components/pages/partners/partner-category/partner-category.tsx
+++ b/components/pages/partners/partner-category/partner-category.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { H3 } from 'components/common/typography/typography';
 
 interface PartnerCategoryProps {
-  categoryName: string
-  id: string
+  categoryName: string;
+  id: string;
 }
 
 import styles from './partner-category.module.scss';
@@ -15,9 +15,7 @@ export const PartnerCategory: React.FC<PartnerCategoryProps> = ({ categoryName, 
       <div className="text-center">
         <H3>{categoryName}</H3>
       </div>
-      <div className={styles.items}>
-        {children}
-      </div>
+      <div className={styles.items}>{children}</div>
     </div>
   );
 };

--- a/components/pages/partners/partner-nav/partner-nav.tsx
+++ b/components/pages/partners/partner-nav/partner-nav.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import slugify from 'slugify';
 
 interface PartnerNavProps {
-  items: string[]
+  items: string[];
 }
 
 import styles from './partner-nav.module.scss';
@@ -10,8 +10,14 @@ import styles from './partner-nav.module.scss';
 export const PartnerNav: React.FC<PartnerNavProps> = ({ items }) => {
   return (
     <div className={styles.items}>
-      {items.map(cat => (
-        <a className={styles.anchorLink} href={`#category-${slugify(cat, { lower: true})}`} key={cat}>{cat}</a>
+      {items.map((cat) => (
+        <a
+          className={styles.anchorLink}
+          href={`#category-${slugify(cat, { lower: true })}`}
+          key={cat}
+        >
+          {cat}
+        </a>
       ))}
     </div>
   );

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,2 +1,2 @@
-export * from './jobs'
-export * from './partners'
+export * from './jobs';
+export * from './partners';

--- a/lib/api/partners.ts
+++ b/lib/api/partners.ts
@@ -1,28 +1,27 @@
 import fs from 'fs';
 import { join } from 'path';
-import YAML from 'yaml'
+import YAML from 'yaml';
 
 const sourcePath = join(process.cwd(), 'data', 'partners', 'partners.yaml');
 
 type Partner = {
-  name: string
-  description: string
-  link: string
-  funded?: boolean
-}
+  name: string;
+  description: string;
+  link: string;
+  funded?: boolean;
+};
 
 type PartnersCategory = {
-  category: string
-  partners: Partner[]
-}
+  category: string;
+  partners: Partner[];
+};
 
-export type AllPartnersData = PartnersCategory[]
-
+export type AllPartnersData = PartnersCategory[];
 
 export function getAllPartners() {
-  const file = fs.readFileSync(sourcePath, 'utf8')
-  const data = YAML.parse(file)
+  const file = fs.readFileSync(sourcePath, 'utf8');
+  const data = YAML.parse(file);
 
   // simple type assertion for mapping convenience in the view
-  return data.partners as AllPartnersData
+  return data.partners as AllPartnersData;
 }

--- a/pages/jobs/index.tsx
+++ b/pages/jobs/index.tsx
@@ -13,10 +13,13 @@ export default function Jobs({ allJobs }) {
   return (
     <>
       <StaticHero
-        headline={<>We're a growing open source community looking for talent. <em>Join Edgeware</em></>}
+        headline={
+          <>
+            We're a growing open source community looking for talent. <em>Join Edgeware</em>
+          </>
+        }
         heroStyle="jobs"
       />
-
 
       <Section id="roles" width="narrow">
         <div className="text-center">

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
-import { GetStaticProps, NextPage } from 'next'
-import slugify from 'slugify'
+import { GetStaticProps, NextPage } from 'next';
+import slugify from 'slugify';
 import { H2 } from '../components/common/typography/typography';
 import { Section } from '../components/common/section/section';
 import { StaticHero } from '../components/common/static-hero/static-hero';
 
-import { PartnerCardList, PartnerCard } from '../components/pages/partners/partner-card/partner-card';
+import {
+  PartnerCardList,
+  PartnerCard,
+} from '../components/pages/partners/partner-card/partner-card';
 import { PartnerCategory } from 'components/pages/partners/partner-category/partner-category';
 import { PartnerNav } from 'components/pages/partners/partner-nav/partner-nav';
 
 import { getAllPartners, AllPartnersData } from 'lib/api';
 
 interface PartnersPageStaticProps {
-  allPartnersByCategory: AllPartnersData
+  allPartnersByCategory: AllPartnersData;
 }
 
 const PartnersPage: NextPage<PartnersPageStaticProps> = ({ allPartnersByCategory }) => {
@@ -29,24 +32,27 @@ const PartnersPage: NextPage<PartnersPageStaticProps> = ({ allPartnersByCategory
           <H2 size="2">Our Partners</H2>
         </div>
 
-        <PartnerNav items={allPartnersByCategory.map(g => g.category)} />
+        <PartnerNav items={allPartnersByCategory.map((g) => g.category)} />
 
         <div>
           {allPartnersByCategory.map((partnerGroup) => (
-            <PartnerCategory categoryName={partnerGroup.category} id={slugify(partnerGroup.category, { lower: true })}>
+            <PartnerCategory
+              key={partnerGroup.category}
+              categoryName={partnerGroup.category}
+              id={slugify(partnerGroup.category, { lower: true })}
+            >
               <PartnerCardList>
-                {partnerGroup.partners.map( (partner) => (
+                {partnerGroup.partners.map((partner) => (
                   <PartnerCard {...partner} key={partner.name} />
                 ))}
               </PartnerCardList>
             </PartnerCategory>
           ))}
         </div>
-
       </Section>
     </>
   );
-}
+};
 
 export const getStaticProps: GetStaticProps<PartnersPageStaticProps> = async () => {
   const allPartnersByCategory = getAllPartners();
@@ -55,11 +61,12 @@ export const getStaticProps: GetStaticProps<PartnersPageStaticProps> = async () 
     props: {
       meta: {
         title: 'Conquering crypto together',
-        description: 'Edgeware is partnering with leading cryptocurrency brands and digital communities to build the future of crypto ecosystem.',
+        description:
+          'Edgeware is partnering with leading cryptocurrency brands and digital communities to build the future of crypto ecosystem.',
       },
-      allPartnersByCategory
+      allPartnersByCategory,
     },
   };
-}
+};
 
-export default PartnersPage
+export default PartnersPage;

--- a/utils/slugify.ts
+++ b/utils/slugify.ts
@@ -1,1 +1,0 @@
-export const slugifyString n


### PR DESCRIPTION
As discussed in Edgeware.Agency group:
- link to the partners page will appear in main nav, replacing Proposals (which will find its place in upcoming "Get Started" layer).

Also fixed bunch of linter warnings that should've been actually done/checked in previous PR as it breaks the build. 
I'll improve tooling around it to avoid such situation in future.