### PR TITLE
Use fixed agency email for GH-Pages publishing action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,5 @@ jobs:
         with:
           branch: gh-pages
           folder: out
+          git-config-name: Edgeware.Agency
+          git-config-email: ops@edgeware.agency


### PR DESCRIPTION
To cleanup some commit messages