### PR TITLE
Tweak text on partners page intro section

### DIFF
--- a/components/common/static-hero/static-hero.module.scss
+++ b/components/common/static-hero/static-hero.module.scss
@@ -85,6 +85,12 @@
   }
 }
 
+.hero--partners {
+  .headlineWrapper {
+    max-width: 920px;
+  }
+}
+
 .headline {
   margin: 0;
 }

--- a/components/common/static-hero/static-hero.tsx
+++ b/components/common/static-hero/static-hero.tsx
@@ -8,7 +8,7 @@ import styles from './static-hero.module.scss';
 
 interface StaticHeroProps {
   headline: React.ReactNode;
-  leadText?: string;
+  leadText?: string | React.ReactNode;
   heroStyle: 'jobs' | 'partners';
 }
 

--- a/pages/partners.tsx
+++ b/pages/partners.tsx
@@ -22,8 +22,14 @@ const PartnersPage: NextPage<PartnersPageStaticProps> = ({ allPartnersByCategory
   return (
     <>
       <StaticHero
-        headline="Conquering crypto together"
-        leadText="Edgeware is partnering with leading cryptocurrency brands and digital communities to build the future of crypto ecosystem."
+        headline="Home to next generation networks"
+        leadText={
+          <>
+            Edgeware partners with leading cryptocurrency teams,
+            <br />
+            projects and collectives to create the future of Web3
+          </>
+        }
         heroStyle="partners"
       />
 
@@ -60,9 +66,9 @@ export const getStaticProps: GetStaticProps<PartnersPageStaticProps> = async () 
   return {
     props: {
       meta: {
-        title: 'Conquering crypto together',
+        title: 'Our Partners - Home to next generation networks',
         description:
-          'Edgeware is partnering with leading cryptocurrency brands and digital communities to build the future of crypto ecosystem.',
+          'Edgeware partners with leading cryptocurrency teams, projects and collectives to create the future of Web3',
       },
       allPartnersByCategory,
     },


### PR DESCRIPTION
Per request from @monsieurbulb tweaked the text on the intro section of Partners page:

<img width="1096" alt="Screenshot 2021-09-15 at 08 35 57" src="https://user-images.githubusercontent.com/16012/133383031-8cea6170-5474-47b5-8c49-64a519ea098b.png">
