### PR TITLE
Domain migration to edgeware.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-[Edgeware](https://edgewa.re/) is a smart contract chain with a community-managed treasury, decentralised proposal system and network of DAOs.
+[Edgeware](https://www.edgeware.io/) is a smart contract chain with a community-managed treasury, decentralised proposal system and network of DAOs.
 
 Edgeware is launched by [Commonwealth Labs](https://commonwealth.im/)
 and built on [Parity Substrate](https://www.parity.io/substrate/).
 We're grateful for the support of many friends, advisors, and community
 members.
 
-This project is a repository of its public-facing website: [https://edgewa.re](https://edgewa.re/)
+This project is a repository of its public-facing website: [https://www.edgeware.io](https://www.edgeware.io/)
 
 ## Contributing
 
@@ -21,10 +21,13 @@ Edgeware website is built with [Next.js](https://nextjs.org/)
 
 Make sure you have Node.js and Yarn installed.
 Install the project dependencies:
+
 ```bash
 yarn
 ```
+
 Run the local development server:
+
 ```bash
 yarn dev
 ```

--- a/components/layout/head/head-open-graph.tsx
+++ b/components/layout/head/head-open-graph.tsx
@@ -1,5 +1,5 @@
-const DOMAIN = 'https://edgewa.re';
-const SITE_NAME = 'edgewa.re';
+const DOMAIN = 'https://www.edgeware.io';
+const SITE_NAME = 'www.edgeware.io';
 
 type HeadOpenGraphProps = {
   pageTitle: string;

--- a/components/pages/keygen/forms/evm-withdraw.tsx
+++ b/components/pages/keygen/forms/evm-withdraw.tsx
@@ -138,7 +138,7 @@ export const EvmWithdraw = () => {
     }
 
     setFormState({ text: 'Connecting to polkadot-js...', error: true });
-    const polkadotUrl = 'wss://edgeware.api.onfinality.io/public-ws';
+    const polkadotUrl = 'wss://edgeware.jelliedowl.net';
     const registry = new TypeRegistry();
     const api = await new ApiPromise({
       provider: new WsProvider(polkadotUrl),
@@ -202,7 +202,7 @@ export const EvmWithdraw = () => {
           {
             chainId: '0x7E5',
             chainName: 'Edgeware',
-            rpcUrls: ['https://edgeware.api.onfinality.io/public-ws/evm'],
+            rpcUrls: ['https://edgeware-evm.jelliedowl.net/'],
             nativeCurrency: {
               name: 'Edgeware',
               symbol: 'EDG',

--- a/components/pages/keygen/forms/evm-withdraw.tsx
+++ b/components/pages/keygen/forms/evm-withdraw.tsx
@@ -138,7 +138,7 @@ export const EvmWithdraw = () => {
     }
 
     setFormState({ text: 'Connecting to polkadot-js...', error: true });
-    const polkadotUrl = 'wss://mainnet.edgewa.re';
+    const polkadotUrl = 'wss://edgeware.api.onfinality.io/public-ws';
     const registry = new TypeRegistry();
     const api = await new ApiPromise({
       provider: new WsProvider(polkadotUrl),
@@ -202,13 +202,13 @@ export const EvmWithdraw = () => {
           {
             chainId: '0x7E5',
             chainName: 'Edgeware',
-            rpcUrls: ['https://mainnet.edgewa.re/evm'],
+            rpcUrls: ['https://edgeware.api.onfinality.io/public-ws/evm'],
             nativeCurrency: {
               name: 'Edgeware',
               symbol: 'EDG',
               decimals: 18,
             },
-            blockExplorerUrls: ['https://mainnet.edgscan.com/'],
+            blockExplorerUrls: ['https://edgscan.live/'],
           },
         ],
       });

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,4 +1,4 @@
 module.exports = {
-  siteUrl: process.env.SITE_URL || 'https://edgewa.re',
+  siteUrl: process.env.SITE_URL || 'https://www.edgeware.io',
   generateRobotsTxt: true,
-}
+};

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -149,11 +149,11 @@ export default function Privacy() {
             <p>
               <strong>Website</strong> refers to Edgeware, accessible from{' '}
               <a
-                href="https://edgewa.re"
+                href="https://www.edgeware.io"
                 rel="external nofollow noopener noreferrer"
                 target="_blank"
               >
-                https://edgewa.re
+                https://www.edgeware.io
               </a>
             </p>
           </li>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@ User-agent: *
 Allow: /
 
 # Host
-Host: https://edgewa.re
+Host: https://www.edgeware.io
 
 # Sitemaps
-Sitemap: https://edgewa.re/sitemap.xml
+Sitemap: https://www.edgeware.io/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://edgewa.re</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/binance</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/collectives</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/contribute</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/developers</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/get-started</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/jobs</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/keygen</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/mission</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/partners</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/press</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/privacy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/jobs/dao-financial-strategist</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/jobs/senior-blockchain-engineer-rust</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
-<url><loc>https://edgewa.re/jobs/wasm-evm-contract-engineer</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-28T19:26:33.702Z</lastmod></url>
+<url><loc>https://www.edgeware.io</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/binance</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/build</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/collectives</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/contribute</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/developers</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/ecosystem</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/get-started</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/keygen</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/partners</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/press</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/privacy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
+<url><loc>https://www.edgeware.io/society</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-08-31T16:05:42.664Z</lastmod></url>
 </urlset>


### PR DESCRIPTION
This PR introduces first set of changes to migrate website from old domain `edgewa.re` to new domain `edgeware.io`
Additionally I've included a set of changes from @ShankarWarang #54 PR

There is bit more to the full migrations, we need to analyze which steps we can do at once initially and which will follow:

- [x] Replace occurrences of main domain in the website codebase to use edgeware.io
- [ ] Adjust GTM/Tracking script to support new domain
- [ ] Setup google search console account and inform google about index change
- [ ] Setup 301 HTTP redirect on root domain level
- [ ] Staking Facilites widget update for supporting new domain
- [ ] Verify website links in docs (it is using https://docs.edgeware.wiki/  domain)
- [ ] Check usage of `www` domain / vs. pure domain

We also have content on subdomains which at some point we need to also clean up and adjust:

- [ ] Redirect blog: https://blog.edgewa.re/  to `blog.edgeware.io`
    - [ ] Update blog configuration
    - [ ] Update links within blog templates
    - [ ] Setup 301 redirects
- [ ] Redirect governance from https://gov.edgewa.re/  to `gov.edgeware.io`
    - [ ] Update website link in the sidebar
- [ ] Redirect / update infrastructure URLs from `mainnet.edgewa.re` -> `mainnet.edgeware.io`

Finally, we need to track down and update/inform 3rd party websites (as much as we can)

- Social media channels
- Infrastructure providers
- Exchanges & trackers

I think we may need to still support `edgewa.re` and it subdomains for quite some time, until the whole ecosystem adopts.

